### PR TITLE
Add FL build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,7 +133,7 @@ jobs:
       - name: "Firelight: generate HTML"
         run: |
           npx --node-options='--experimental-vm-modules' \
-            -y @riboseinc/anafero-cli@0.0.46 \
+            -y @riboseinc/anafero-cli@0.0.47 \
             --target-dir dist \
             --path-prefix /cc-admin-documents \
             --current-rev main \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: "Firelight: commit"
         run: |
+          ls -Al
           git add _site/documents.xml
           git commit -m "Commit MN XML"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mn
+          path: _site
 
       - name: "Firelight: create temporary Git repo"
         run: |
@@ -59,10 +60,10 @@ jobs:
 
       - name: "Firelight: commit"
         run: |
-          ls -Al documents/cc-0001-report-ioptest
-          git add documents.xml
-          git add **/*.pdf
-          git add **/*.xml
+          ls -Al _site/documents/cc-0001-report-ioptest
+          git add _site/documents.xml
+          git add _site/**/*.pdf
+          git add _site/**/*.xml
           git commit -m "Commit MN XML & PDF artifacts"
 
       - name: "Firelight: prepare config"
@@ -70,7 +71,7 @@ jobs:
           cat <<'EOF' >> anafero-config.json
           {
             "version": "0.1",
-            "entryPoint": "file:documents.xml",
+            "entryPoint": "file:_site/documents.xml",
             "storeAdapters": [
               "git+https://github.com/metanorma/firelight#collection-support/packages/relaton-collection-xml-store",
               "git+https://github.com/metanorma/firelight#collection-support/packages/metanorma-xml-store"
@@ -90,14 +91,14 @@ jobs:
         run: |
           npx --node-options='--experimental-vm-modules' \
             -y @riboseinc/anafero-cli@0.0.43 \
-            --target-dir _site \
+            --target-dir dist \
             --path-prefix /cc-admin-documents \
             --current-rev main
 
       - uses: actions/upload-artifact@v4
         with:
           name: fl
-          path: _site
+          path: dist
           if-no-files-found: error
 
   deploy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,7 +133,7 @@ jobs:
       - name: "Firelight: generate HTML"
         run: |
           npx --node-options='--experimental-vm-modules' \
-            -y @riboseinc/anafero-cli@0.0.45 \
+            -y @riboseinc/anafero-cli@0.0.46 \
             --target-dir dist \
             --path-prefix /cc-admin-documents \
             --current-rev main \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Firelight: commit"
         run: |
-          ls -Al
+          ls -Al documents
           git add documents.xml
           git add **/*.pdf
           git add **/*.xml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,7 +133,7 @@ jobs:
       - name: "Firelight: generate HTML"
         run: |
           npx --node-options='--experimental-vm-modules' \
-            -y @riboseinc/anafero-cli@0.0.44 \
+            -y @riboseinc/anafero-cli@0.0.45 \
             --target-dir dist \
             --path-prefix /cc-admin-documents \
             --current-rev main \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,7 @@ jobs:
           destination: artifact
           artifact-name: mn
           agree-to-terms: true
+          cache-site-for-manifest: metanorma.yml
 
   fl-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,7 +93,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mn
-          path: _site
 
       - name: "Firelight: create temporary Git repo"
         run: |
@@ -104,10 +103,10 @@ jobs:
 
       - name: "Firelight: commit"
         run: |
-          ls -Al _site/documents/cc-0001-report-ioptest
-          git add _site/documents.xml
-          git add _site/**/*.pdf
-          git add _site/**/*.xml
+          ls -Al documents/cc-0001-report-ioptest
+          git add documents.xml
+          git add **/*.pdf
+          git add **/*.xml
           git commit -m "Commit MN XML & PDF artifacts"
 
       - name: "Firelight: prepare config"
@@ -115,7 +114,7 @@ jobs:
           cat <<'EOF' >> anafero-config.json
           {
             "version": "0.1",
-            "entryPoint": "file:_site/documents.xml",
+            "entryPoint": "file:documents.xml",
             "storeAdapters": [
               "git+https://github.com/metanorma/firelight#collection-support/packages/relaton-collection-xml-store",
               "git+https://github.com/metanorma/firelight#collection-support/packages/metanorma-xml-store"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -136,7 +136,8 @@ jobs:
             -y @riboseinc/anafero-cli@0.0.44 \
             --target-dir dist \
             --path-prefix /cc-admin-documents \
-            --current-rev main
+            --current-rev main \
+            --debug
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,12 +29,73 @@ jobs:
       - name: Bundler install
         uses: metanorma/ci/docker-gem-install@main
 
-      - name: Metanorma generate site
+      - name: Print Metanorma version
+        run: metanorma --version
+
+      - name: Generate Metanorma XML
         uses: actions-mn/build-and-publish@v2
         with:
-          destination: gh-pages
+          destination: artifact
+          artifact-name: mn
           agree-to-terms: true
-          use-bundler: true
+
+  fl-build:
+    runs-on: ubuntu-latest
+    needs: build
+    name: Build Firelight version
+
+    steps:
+      - name: Download Metanorma artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mn
+
+      - name: "Firelight: create temporary Git repo"
+        run: |
+          git config --global user.email "57123902+metanorma-ci@users.noreply.github.com"
+          git config --global user.name "Metanorma CI"
+          git config --global init.defaultBranch main
+          git init .
+
+      - name: "Firelight: commit"
+        run: |
+          git add documents/_site/documents.xml
+          git commit -m "Commit MN XML"
+
+      - name: "Firelight: prepare config"
+        run: |
+          cat <<'EOF' >> anafero-config.json
+          {
+            "version": "0.1",
+            "entryPoint": "file:_site/documents.xml",
+            "storeAdapters": [
+              "git+https://github.com/metanorma/firelight#collection-support/packages/relaton-collection-xml-store",
+              "git+https://github.com/metanorma/firelight#collection-support/packages/metanorma-xml-store"
+            ],
+            "contentAdapters": [
+              "git+https://github.com/metanorma/firelight#collection-support/packages/metanorma-site-content"
+            ],
+            "resourceLayouts": [
+              "git+https://github.com/metanorma/firelight#collection-support/packages/plateau-layout"
+            ]
+          }
+          EOF
+          git add anafero-config.json
+          git commit -m "Add build config"
+
+      - name: "Firelight: generate HTML"
+        run: |
+          npx --node-options='--experimental-vm-modules' \
+            -y @riboseinc/anafero-cli@0.0.42 \
+            --target-dir _site \
+            --path-prefix /cc-admin-documents \
+            --current-rev main
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fl
+          path: _site
+          if-no-files-found: error
 
   deploy:
     if: ${{ github.ref_name == github.event.repository.default_branch }}
@@ -42,8 +103,28 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: fl-build
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Make dist dir
+        run: mkdir dist
+
+      - name: Download HTML artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: fl
+          path: dist
+
+      - name: List files in dist
+        run: ls -l dist
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Firelight: commit"
         run: |
-          git add documents/_site/documents.xml
+          git add _site/documents.xml
           git commit -m "Commit MN XML"
 
       - name: "Firelight: prepare config"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,8 +60,10 @@ jobs:
       - name: "Firelight: commit"
         run: |
           ls -Al
-          git add _site/documents.xml
-          git commit -m "Commit MN XML"
+          git add documents.xml
+          git add **/*.pdf
+          git add **/*.xml
+          git commit -m "Commit MN XML & PDF artifacts"
 
       - name: "Firelight: prepare config"
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,7 @@ jobs:
       - name: "Firelight: generate HTML"
         run: |
           npx --node-options='--experimental-vm-modules' \
-            -y @riboseinc/anafero-cli@0.0.42 \
+            -y @riboseinc/anafero-cli@0.0.43 \
             --target-dir _site \
             --path-prefix /cc-admin-documents \
             --current-rev main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -134,7 +134,7 @@ jobs:
       - name: "Firelight: generate HTML"
         run: |
           npx --node-options='--experimental-vm-modules' \
-            -y @riboseinc/anafero-cli@0.0.43 \
+            -y @riboseinc/anafero-cli@0.0.44 \
             --target-dir dist \
             --path-prefix /cc-admin-documents \
             --current-rev main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Firelight: commit"
         run: |
-          ls -Al documents
+          ls -Al documents/cc-0001-report-ioptest
           git add documents.xml
           git add **/*.pdf
           git add **/*.xml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,14 +31,57 @@ jobs:
 
       - name: Print Metanorma version
         run: metanorma --version
+      # In case of cache miss, the generate MN XML step will run
+      # and the cache will be filled after job finishes.
+      # Next time it’ll be a cache hit, unless sources changed.
+      # See also “Upload cached Metanorma XML” step, which is important.
+      - name: Restore cached Metanorma XML, if any
+        id: cache-mn-xml
+        uses: actions/cache@v4
+        env:
+          cache-name: _site
+        with:
+          path: _site
+
+          # NOTE: cache key does not include current MN version,
+          # which means if sources did not change but it’s desirable
+          # to rebuild XML using a newer MN version it may be impossible to do
+          # without making a dummy/meaningless change in the content
+          # to change the hash.
+          #
+          # The proper way to address this could be pinning MN version
+          # somewhere and including it as part of the hash here;
+          # alternatively, if we really want to always use whatever MN version
+          # is latest, we could detect that version and include it
+          # as part of this key.
+          key: ${{ runner.os }}-mn-${{ env.cache-name }}-${{ hashFiles('sources/00*-v5/**', 'sources/xmi/**', 'sources/liquid_templates/**', 'sources/guidance/**') }}
+
+          # We can fuzzy-match latest available cache,
+          # instead of precise hash.
+          # This can speed up build in some scenarios,
+          # but can in theory also cause issues where XML is not updated
+          # after source changes.
+          # restore-keys: |
+          #   ${{ runner.os }}-mn-${{ env.cache-name }}-
+          #   ${{ runner.os }}-mn-
+          #   ${{ runner.os }}-
 
       - name: Generate Metanorma XML
         uses: actions-mn/build-and-publish@v2
+        if: steps.cache-mn-xml.outputs.cache-hit != 'true'
         with:
           destination: artifact
           artifact-name: mn
           agree-to-terms: true
-          cache-site-for-manifest: metanorma.yml
+
+      # In case of cache hit, we must explicitly upload the _site dir as artifact
+      - name: Upload cached Metanorma XML
+        uses: actions/upload-artifact@v4
+        if: steps.cache-mn-xml.outputs.cache-hit == 'true'
+        with:
+          name: mn
+          path: _site
+          if-no-files-found: error
 
   fl-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -145,6 +145,11 @@ jobs:
           path: dist
           if-no-files-found: error
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fl-cache-dump
+          path: cacheDump.json
+
   deploy:
     if: ${{ github.ref_name == github.event.repository.default_branch }}
     environment:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,7 +70,7 @@ jobs:
           cat <<'EOF' >> anafero-config.json
           {
             "version": "0.1",
-            "entryPoint": "file:_site/documents.xml",
+            "entryPoint": "file:documents.xml",
             "storeAdapters": [
               "git+https://github.com/metanorma/firelight#collection-support/packages/relaton-collection-xml-store",
               "git+https://github.com/metanorma/firelight#collection-support/packages/metanorma-xml-store"


### PR DESCRIPTION
Metanorma XML caching is _required_, because apparently the MN action does not handle it (https://github.com/actions-mn/build-and-publish/issues/21). Without this, the action generates XML every time, painfully slowly. Caches can be manually pruned via Actions -> Management -> Caches.