### PR TITLE
feat: switch to pattern-based channel manifest

### DIFF
--- a/.metanorma/channels.yml
+++ b/.metanorma/channels.yml
@@ -1,0 +1,14 @@
+# .metanorma/channels.yml — CalConnect Administrative Documents
+#
+# Declares channels published by this repo for efficient discovery
+# by actions-mn/aggregate.
+
+channels:
+  - name: public/standards
+    description: "Published CalConnect Standards"
+  - name: public/reports
+    description: "Conference, roundtable, and IOP test reports"
+  - name: public/admin
+    description: "Administrative documents (conference minutes, agendas)"
+  - name: public/advisories
+    description: "CalConnect advisories"

--- a/metanorma.release.yml
+++ b/metanorma.release.yml
@@ -1,149 +1,31 @@
+# metanorma.release.yml — CalConnect Administrative Documents
+#
+# Pattern-based channel assignment. Documents not matching any pattern
+# are NOT released (safe-by-default: no defaults section).
+#
+# Document ID convention:
+#   cc-s-*   → Standards     → public/standards
+#   cc-r-*   → Reports       → public/reports
+#   cc-a-*   → Admin docs    → public/admin
+#   cc-adv-* → Advisories    → public/advisories
+#
+# Authors: add your document source. If the compiled document ID follows
+# the convention above, it will be automatically released to the correct
+# channel. No manifest update needed.
+
 documents:
-  - source: sources/cc-0001-report-ioptest/document.adoc
-  - source: sources/cc-0101-report-ioptest/document.adoc
-  - source: sources/cc-0201-report-ioptest/document.adoc
-  - source: sources/cc-0401-ioptest-rules/document.adoc
-  - source: sources/cc-0402-ioptest-results/document.adoc
-  - source: sources/cc-0403-report-ioptest/document.adoc
-  - source: sources/cc-0404-report-roundtable-1/document.adoc
-  - source: sources/cc-0501-ioptest-rules/document.adoc
-  - source: sources/cc-0502-report-ioptest/document.adoc
-  - source: sources/cc-0503-ioptest-rules/document.adoc
-  - source: sources/cc-0504-report-ioptest/document.adoc
-  - source: sources/cc-0505-questionnaire-results-recurrence/document.adoc
-  - source: sources/cc-0506-report-ioptest/document.adoc
-  - source: sources/cc-0507-caldav-use-cases/document.adoc
-  - source: sources/cc-0508-pres-overview/document.adoc
-  - source: sources/cc-0509-pres-overview/document.adoc
-  - source: sources/cc-0510-questionnaire-results-timezone/document.adoc
-  - source: sources/cc-0511-report-roundtable-2/document.adoc
-  - source: sources/cc-0512-report-roundtable-3/document.adoc
-  - source: sources/cc-0513-report-roundtable-4/document.adoc
-  - source: sources/cc-0514-dst-adv-notice/document.adoc
-  - source: sources/cc-0601-miniop-usecases-1.0/document.adoc
-  - source: sources/cc-0601-miniop-usecases-v1.1/document.adoc
-  - source: sources/cc-0602-ical-tz-problems/document.adoc
-  - source: sources/cc-0603-report-ioptest/document.adoc
-  - source: sources/cc-0604-ical-recurrence-problems/document.adoc
-  - source: sources/cc-0605-pres-omads-briefing/document.adoc
-  - source: sources/cc-0606-timezone-registry/document.adoc
-  - source: sources/cc-0607-report-ioptest/document.adoc
-  - source: sources/cc-0608-pres-fb-demo/document.adoc
-  - source: sources/cc-0609-questionnaire-results-mobcal/document.adoc
-  - source: sources/cc-0610-cs-glossary-v1/document.adoc
-  - source: sources/cc-0611-ical-benefits/document.adoc
-  - source: sources/cc-0612-report-ioptest/document.adoc
-  - source: sources/cc-0613-report-roundtable-5/document.adoc
-  - source: sources/cc-0614-report-roundtable-6/document.adoc
-  - source: sources/cc-0615-report-roundtable-7/document.adoc
-  - source: sources/cc-0701-miniop-usecases-tasks/document.adoc
-  - source: sources/cc-0702-report-ioptest/document.adoc
-  - source: sources/cc-0703-caldav-scheduling-reqs/document.adoc
-  - source: sources/cc-0704-report-ioptest/document.adoc
-  - source: sources/cc-0705-pres-overview/document.adoc
-  - source: sources/cc-0706-ioptest-suite/document.adoc
-  - source: sources/cc-0706-ioptest-suite-v1.1/document.adoc
-  - source: sources/cc-0707-edst-reflections-v1/document.adoc
-  - source: sources/cc-0707-edst-reflections-v1.1/document.adoc
-  - source: sources/cc-0708-dst-review/document.adoc
-  - source: sources/cc-0709-dst-links/document.adoc
-  - source: sources/cc-0710-report-ioptest/document.adoc
-  - source: sources/cc-0711-report-roundtable-8/document.adoc
-  - source: sources/cc-0712-report-roundtable-9/document.adoc
-  - source: sources/cc-0713-report-roundtable-10/document.adoc
-  - source: sources/cc-0714-report-vcard-workshop/document.adoc
-  - source: sources/cc-0801-pres-preview-roundtable-11/document.adoc
-  - source: sources/cc-0802-report-ioptest/document.adoc
-  - source: sources/cc-0803-report-ioptest/document.adoc
-  - source: sources/cc-0804-report-ioptest/document.adoc
-  - source: sources/cc-0805-mobile-recurrence-iop/document.adoc
-  - source: sources/cc-0806-pres-preview-roundtable-13/document.adoc
-  - source: sources/cc-0807-report-ioptest/document.adoc
-  - source: sources/cc-0808-report-ioptest/document.adoc
-  - source: sources/cc-0809-report-roundtable-11/document.adoc
-  - source: sources/cc-0810-report-roundtable-12/document.adoc
-  - source: sources/cc-0811-report-roundtable-13/document.adoc
-  - source: sources/cc-0812-pres-meet-cc/pres-intro-01.adoc
-  - source: sources/cc-0812-pres-meet-cc/pres-intro-02.adoc
-  - source: sources/cc-0812-pres-meet-cc/pres-iop-testing.adoc
-  - source: sources/cc-0812-pres-meet-cc/pres-ischedule.adoc
-  - source: sources/cc-0812-pres-meet-cc/pres-tc-mobile.adoc
-  - source: sources/cc-0812-pres-meet-cc/pres-bedework.adoc
-  - source: sources/cc-0812-pres-meet-cc/pres-stockholm.adoc
-  - source: sources/cc-0901-report-roundtable-14/document.adoc
-  - source: sources/cc-0902-report-ioptest/document.adoc
-  - source: sources/cc-0903-freebusy-read-url/document.adoc
-  - source: sources/cc-0904-xcal/document.adoc
-  - source: sources/cc-0905-state-of-resource-iop/document.adoc
-  - source: sources/cc-0906-resources-usecases/document.adoc
-  - source: sources/cc-0907-miniop-resource-info/document.adoc
-  - source: sources/cc-0908-report-roundtable-15/document.adoc
-  - source: sources/cc-0909-report-ioptest/document.adoc
-  - source: sources/cc-0910-report-roundtable-16/document.adoc
-  - source: sources/cc-0911-report-ioptest/document.adoc
-  - source: sources/cc-1001-report-roundtable-17/document.adoc
-  - source: sources/cc-1002-report-ioptest/document.adoc
-  - source: sources/cc-1003-schema-resources/document.adoc
-  - source: sources/cc-1004-calws-api/document.adoc
-  - source: sources/cc-1005-report-roundtable-18/document.adoc
-  - source: sources/cc-1006-link-extension/document.adoc
-  - source: sources/cc-1007-timezone-protocol/document.adoc
-  - source: sources/cc-1008-timezone-xml/document.adoc
-  - source: sources/cc-1009-report-ioptest/document.adoc
-  - source: sources/cc-1010-report-ioptest/document.adoc
-  - source: sources/cc-1011-calws-rest-v1/document.adoc
-  - source: sources/cc-1011-calws-rest-v1.0.1/document.adoc
-  - source: sources/cc-1012-ical-intro-v1/document.adoc
-  - source: sources/cc-1012-ical-intro-v1.1/document.adoc
-  - source: sources/cc-1013-report-roundtable-19/document.adoc
-  - source: sources/cc-1014-report-ioptest/document.adoc
-  - source: sources/cc-1101-ical-extensions/document.adoc
-  - source: sources/cc-1102-cs-glossary-v2/document.adoc
-  - source: sources/cc-1103-report-roundtable-20/document.adoc
-  - source: sources/cc-1104-cs-index/document.adoc
-  - source: sources/cc-1105-report-roundtable-21/document.adoc
-  - source: sources/cc-1106-report-roundtable-22/document.adoc
-  - source: sources/cc-1201-report-roundtable-23/document.adoc
-  - source: sources/cc-1202-calws-soap/document.adoc
-  - source: sources/cc-1203-report-roundtable-24/document.adoc
-  - source: sources/cc-1204-report-roundtable-25/document.adoc
-  - source: sources/cc-1301-calws-soap/document.adoc
-  - source: sources/cc-1302-report-roundtable-26/document.adoc
-  - source: sources/cc-1303-report-ioptestevent-26/document.adoc
-  - source: sources/cc-1304-report-roundtable-27/document.adoc
-  - source: sources/cc-1305-report-ioptestevent-27/document.adoc
-  - source: sources/cc-1306-report-roundtable-28/document.adoc
-  - source: sources/cc-1307-report-ioptestevent-28/document.adoc
-  - source: sources/cc-1401-report-roundtable-29/document.adoc
-  - source: sources/cc-1402-report-ioptestevent-29/document.adoc
-  - source: sources/cc-1403-workshop-30/document.adoc
-  - source: sources/cc-1404-report-ioptestevent-30/document.adoc
-  - source: sources/cc-1405-report-conference-30/document.adoc
-  - source: sources/cc-1406-report-conference-31/document.adoc
-  - source: sources/cc-1407-report-ioptestevent-31/document.adoc
-  - source: sources/cc-1501-report-conference-32/document.adoc
-  - source: sources/cc-1502-report-ioptestevent-32/document.adoc
-  - source: sources/cc-1503-report-conference-33/document.adoc
-  - source: sources/cc-1504-report-ioptestevent-33/document.adoc
-  - source: sources/cc-1505-report-ioptestevent-34/document.adoc
-  - source: sources/cc-1506-report-conference-34/document.adoc
-  - source: sources/cc-1601-report-conference-35/document.adoc
-  - source: sources/cc-1602-report-ioptestevent-35/document.adoc
-  - source: sources/cc-1603-report-conference-36/document.adoc
-  - source: sources/cc-1604-report-ioptestevent-36/document.adoc
-  - source: sources/cc-1605-report-conference-37/document.adoc
-  - source: sources/cc-1606-report-ioptestevent-37/document.adoc
-  - source: sources/cc-1701-report-conference-38/document.adoc
-  - source: sources/cc-1702-report-ioptestevent-38/document.adoc
-  - source: sources/cc-1703-report-conference-39/document.adoc
-  - source: sources/cc-1704-report-ioptestevent-39/document.adoc
-  - source: sources/cc-1705-report-conference-40/document.adoc
-  - source: sources/cc-1706-report-ioptestevent-40/document.adoc
-  - source: sources/cc-1801-report-conference-41/document.adoc
-  - source: sources/cc-1802-report-ioptestevent-41/document.adoc
-  - source: sources/cc-1803-report-conference-42/document.adoc
-  - source: sources/cc-1804-report-ioptestevent-42/document.adoc
-  - source: sources/cc-1805-report-conference-43/document.adoc
-  - source: sources/cc-1901-report-conference-44/document.adoc
-  - source: sources/cc-1902-report-conference-45/document.adoc
-  - source: sources/cc-1903-report-conference-46/document.adoc
+  # ── Standards ────────────────────────────────────────────────
+  - pattern: "cc-s-*"
+    channels: [public/standards]
+
+  # ── Reports ──────────────────────────────────────────────────
+  - pattern: "cc-r-*"
+    channels: [public/reports]
+
+  # ── Administrative documents ─────────────────────────────────
+  - pattern: "cc-a-*"
+    channels: [public/admin]
+
+  # ── Advisories ───────────────────────────────────────────────
+  - pattern: "cc-adv-*"
+    channels: [public/advisories]


### PR DESCRIPTION
Replace the 150-line explicit source list with 4 pattern entries that auto-assign channels by document ID convention:

```
cc-s-*   → public/standards
cc-r-*   → public/reports
cc-a-*   → public/admin
cc-adv-* → public/advisories
```

Also adds `.metanorma/channels.yml` for efficient repo discovery by `actions-mn/aggregate`.

**Safe-by-default**: no `defaults` section means unmatched documents default to private (not released).

This PR is part of the channel-based publication migration. See `METANORMA-PUBLISH.md` in `actions-mn/release` for the full architecture.